### PR TITLE
remove semicolons from python starter and fix type hinting

### DIFF
--- a/kits/python/bot.py
+++ b/kits/python/bot.py
@@ -20,18 +20,18 @@ while True:
     commands = []
 
     # player is your player object, opponent is the opponent's
-    player = agent.players[agent.id];
-    opponent = agent.players[(agent.id + 1) % 2];
+    player = agent.players[agent.id]
+    opponent = agent.players[(agent.id + 1) % 2]
 
     # all your collectorunits
-    my_units = player.units;
+    my_units = player.units
 
     # all your bases
-    my_bases = player.bases;
+    my_bases = player.bases
 
     # use print("msg", file=sys.stderr) to print messages to the terminal or your error log.
     # normal prints are reserved for the match engine. Uncomment the lines below to log something
-    # print('Turn {} | ID: {} - {} bases - {} units - energium {}'.format(agent.turn, player.team, len(my_bases), len(my_units), player.energium), file=sys.stderr);
+    # print('Turn {} | ID: {} - {} bases - {} units - energium {}'.format(agent.turn, player.team, len(my_bases), len(my_units), player.energium), file=sys.stderr)
 
     ### AI Code goes here ###
 
@@ -40,7 +40,7 @@ while True:
 
     # spawn unit until we have 4 units
     if len(my_units) < 4 and player.energium >= GAME_CONSTANTS["PARAMETERS"]["UNIT_COST"]:
-        commands.append(my_bases[0].spawn_unit());
+        commands.append(my_bases[0].spawn_unit())
     
     # iterate over all of our collectors and make them do something
     for unit in my_units:

--- a/kits/python/energium/kit.py
+++ b/kits/python/energium/kit.py
@@ -1,4 +1,4 @@
-
+from typing import List
 from .game_objects import Base, Player, Unit
 from .map import GameMap
 
@@ -29,15 +29,15 @@ class Agent:
         mapInfo = read_input().split(" ")
         width = int(mapInfo[0])
         height = int(mapInfo[1])
-        self.mapWidth = width;
-        self.mapHeight = height;
-        self.map = GameMap(width, height);
-        self.players: list[Player] = [Player(0), Player(1)];
+        self.mapWidth = width
+        self.mapHeight = height
+        self.map = GameMap(width, height)
+        self.players: List[Player] = [Player(0), Player(1)]
         self.retrieve_updates()
 
     def resetPlayerStates(self):
-        self.players[0].units = [];
-        self.players[1].units = [];
+        self.players[0].units = []
+        self.players[1].units = []
 
     def retrieve_updates(self):
         self.resetPlayerStates()
@@ -51,13 +51,13 @@ class Agent:
                 team = int(update[1])
                 x = int(update[2])
                 y = int(update[3])
-                self.players[team].bases.append(Base(team, x, y));
+                self.players[team].bases.append(Base(team, x, y))
             elif input_id == 't':
                 x = int(update[1])
                 y = int(update[2])
                 pts = int(update[3])
-                tile = self.map.get_tile(x, y);
-                tile.energium = pts;
+                tile = self.map.get_tile(x, y)
+                tile.energium = pts
             elif input_id == 'p':
                 team = int(update[1])
                 pts = int(update[2])
@@ -68,7 +68,7 @@ class Agent:
                 x = int(update[3])
                 y = int(update[4])
                 lrt = int(update[5])
-                self.players[team].units.append(Unit(team, unitid, x, y, lrt, self.turn));
+                self.players[team].units.append(Unit(team, unitid, x, y, lrt, self.turn))
 
 
 

--- a/kits/python/energium/position.py
+++ b/kits/python/energium/position.py
@@ -12,8 +12,8 @@ class Position:
         """
         returns true if this position is adjacent to pos
         """
-        dx = self.x - pos.x;
-        dy = self.y - pos.y;
+        dx = self.x - pos.x
+        dy = self.y - pos.y
         if (math.abs(dx) + math.abs(dy) > 1):
             return False
         return True
@@ -37,7 +37,7 @@ class Position:
         """
         dx = pos.x - self.x
         dy = pos.y - self.y
-        return math.sqrt(dx * dx + dy * dy);
+        return math.sqrt(dx * dx + dy * dy)
 
     def direction_to(self, targetPos):
         """
@@ -48,7 +48,7 @@ class Position:
             DIRECTIONS.EAST,
             DIRECTIONS.SOUTH,
             DIRECTIONS.WEST,
-        ];
+        ]
         closestDirection = None
         closestDist = self.distance_to(targetPos)
         for dir in checkDirections:


### PR DESCRIPTION
semicolons removed from python starter

type hinting for `list` in kit.py fixed.