### PR TITLE
Add CORS origin header to Apache proxy

### DIFF
--- a/server/000-default.conf
+++ b/server/000-default.conf
@@ -8,6 +8,7 @@
 	# However, you must set it for any further virtual host explicitly.
 	#ServerName www.example.com
 
+	Header set Access-Control-Allow-Origin "https://ai.acmucsd.com"
 	ServerAdmin webmaster@localhost
 	DocumentRoot /var/www/html
  	ProxyRequests off	

--- a/server/start.sh
+++ b/server/start.sh
@@ -14,6 +14,7 @@ cp ./000-default.conf /etc/apache2/sites-available/
 
 # change the configs
 a2enmod proxy 
+a2enmod headers
 a2enmod proxy_http
 a2enmod proxy_balancer
 a2enmod lbmethod_byrequests


### PR DESCRIPTION
CORS errors would appear whenever Energium server would spontaneously break connection to the proxy. Add CORS headers on side of Apache proxy to guarantee CORS will continue to list proper origins even with proxy error.

Testing is required, however unlikely this change might drop requests for the server.