### PR TITLE
Position changes in Python Starterkit

### DIFF
--- a/kits/python/energium/game_objects.py
+++ b/kits/python/energium/game_objects.py
@@ -26,6 +26,7 @@ class Unit:
         """
         return (self.match_turn - self.last_repair_turn) / GAME_CONSTANTS['PARAMETERS']['BREAKDOWN_TURNS'];
     def move(self, dir):
+        self.pos = self.pos.translate(dir, 1)
         return 'm {} {}'.format(self.id, dir)
 
 class Player:

--- a/kits/python/energium/position.py
+++ b/kits/python/energium/position.py
@@ -44,7 +44,8 @@ class Position:
         closest_direction = None
         taxicab_dist = taxicab_distance(self, target)
         bigger_side_length = max(abs(self.x - target.x), abs(self.y - target.y))
-        for dir in ALL_DIRECTIONS: # ALL_DIRECTIONS is defined at the top of bot.py
+        for dir in [DIRECTIONS.NORTH, DIRECTIONS.EAST,
+                    DIRECTIONS.SOUTH, DIRECTIONS.WEST]:
             newpos = self.translate(dir, 1)
             dist = taxicab_distance(newpos, target)
             if dist < taxicab_dist:

--- a/kits/python/energium/position.py
+++ b/kits/python/energium/position.py
@@ -5,6 +5,9 @@ class Position:
         self.x = x
         self.y = y
 
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y
+
     def equals(self, opos):
         return self.x == opos.x and self.y == opos.y
 
@@ -35,26 +38,22 @@ class Position:
         """
         returns euclidean distance to the pos from this position
         """
-        dx = pos.x - self.x
-        dy = pos.y - self.y
-        return math.sqrt(dx * dx + dy * dy)
+        return abs(self.x - pos.x) + abs(self.y - pos.y)
 
-    def direction_to(self, targetPos):
-        """
-        gives direction that moves closest to targetPos from this position or None if staying put is closer
-        """
-        checkDirections = [
-            DIRECTIONS.NORTH,
-            DIRECTIONS.EAST,
-            DIRECTIONS.SOUTH,
-            DIRECTIONS.WEST,
-        ]
-        closestDirection = None
-        closestDist = self.distance_to(targetPos)
-        for dir in checkDirections:
+    def direction_to(self, target):
+        closest_direction = None
+        taxicab_dist = taxicab_distance(self, target)
+        bigger_side_length = max(abs(self.x - target.x), abs(self.y - target.y))
+        for dir in ALL_DIRECTIONS: # ALL_DIRECTIONS is defined at the top of bot.py
             newpos = self.translate(dir, 1)
-            dist = targetPos.distance_to(newpos)
-            if (dist < closestDist):
-                closestDist = dist
-                closestDirection = dir
-        return closestDirection
+            dist = taxicab_distance(newpos, target)
+            if dist < taxicab_dist:
+                taxicab_dist = dist
+                bigger_side_length = max(abs(newpos.x - target.x), abs(newpos.y - target.y))
+                closest_direction = dir
+            elif dist == taxicab_dist:
+                s = max(abs(newpos.x - target.x), abs(newpos.y - target.y))
+                if s < bigger_side_length:
+                    bigger_side_length = s
+                    closest_direction = dir
+        return closest_direction

--- a/kits/python/energium/position.py
+++ b/kits/python/energium/position.py
@@ -38,9 +38,40 @@ class Position:
         """
         returns euclidean distance to the pos from this position
         """
+        dx = pos.x - self.x
+        dy = pos.y - self.y
+        return math.sqrt(dx * dx + dy * dy)
+
+    def direction_to(self, targetPos):
+        """
+        gives direction that moves closest to targetPos from this position or None if staying put is closer
+        """
+        checkDirections = [
+            DIRECTIONS.NORTH,
+            DIRECTIONS.EAST,
+            DIRECTIONS.SOUTH,
+            DIRECTIONS.WEST,
+        ]
+        closestDirection = None
+        closestDist = self.distance_to(targetPos)
+        for dir in checkDirections:
+            newpos = self.translate(dir, 1)
+            dist = targetPos.distance_to(newpos)
+            if (dist < closestDist):
+                closestDist = dist
+                closestDirection = dir
+        return closestDirection
+
+    def taxicab_distance_to(self, pos):
+        """
+        returns taxicab distance to the pos from this position
+        """
         return abs(self.x - pos.x) + abs(self.y - pos.y)
 
-    def direction_to(self, target):
+    def direction_to_quick(self, target):
+        """
+        Same as direction_to but runs quicker.
+        """
         closest_direction = None
         taxicab_dist = taxicab_distance(self, target)
         bigger_side_length = max(abs(self.x - target.x), abs(self.y - target.y))


### PR DESCRIPTION
I only changed them in the Python kit, but feel free to duplicate the changes to Javascript/Java.

Changes:
- When `Unit.move` is called it changes the unit's position as well. That way people don't have to update the position themselves after they've already moved it.
- Equality comparison between positions. Now you should be able to write `pos1 == pos2` and it will work the same as `pos1.equals(pos2)`.
- `taxicab_distance_to` gives the Manhattan distance. It's both much quicker than `distance_to` and also gives a more accurate representation of distance as units can only move in the four cardinal directions.
- `direction_to_quick` gives the same result as `direction_to` but it runs much quicker.